### PR TITLE
Modify CRTFileManager to not hard wire schema root.

### DIFF
--- a/ubcrt/CRT/CRTFileManager.h
+++ b/ubcrt/CRT/CRTFileManager.h
@@ -13,22 +13,36 @@
 //
 //           1.  Locating swizzled CRT files that match an art event time stamp.
 //
-//           2.  Opening swizzled CRT files (using xrootd), and positioning them
-//               at the correct position for matching.
+//           2.  Opening swizzled CRT files (locally or using xrootd), and
+//               positioning them at the correct position for matching.
 //
 //           Swizzled CRT files are maintained as open files accross multiple
 //           art modules and art events.
 //
 // FCL paramters:
 //
-// Debug      - Debug flag.
-// MaxFiles   - Maximum number of open gallery files to cache.
+// debug      - Debug flag.
+// maxFiles   - Maximum number of open gallery files to cache.
 // ubversion_CRTHits - Swizzled CRT version.
 // ubversion_CRTHits_top - Swizzled CRT version for top panel CRT hits (stream 1).
 //                         Optional, default same as ubversion_CRTHits.
 // CRTMetadataDir - Directory containing extracted CRT metadata.  If defined,
 //                  CRT metadata will be looked up in this directory instead
 //                  of being queried from SAM.
+// Schema     - SAM schema used for reading CRT files ("root", "file", or "https").
+//              If this parameter is missing, this service will use the schema
+//              specified by environment variable CRT_SCHEMA (if defined).
+//              Otherwise, this service will attempt to make an intelligent choice
+//              for a default schema, based on the following information:
+//              1.  Xrootd_version.
+//              2.  Availability of valid proxy.
+//              3.  Availability of /pnfs filesystem.
+//              In general, default schema "root" is the most preferred schema,
+//              if xrootd version is new enough, or if a valid proxy is available,
+//              Next preferred schema is "file," if /pnfs filesystem is mounted.
+//              The last resort schema is "https."
+//              If schema "https" is chosen, by choice or by default, then CRT
+//              files are copied to this node, which can require a lot of disk space.
 // 
 //
 ////////////////////////////////////////////////////////////////////////
@@ -68,9 +82,10 @@ public:
     std::vector<std::string> fSwizzled;    // Names of CRT swizzled files.
   };
 
+  // Constructor, destructor.
+
   explicit CRTFileManager(fhicl::ParameterSet const & p, art::ActivityRegistry & areg);
-  // The compiler-generated destructor is fine for non-base
-  // classes without bare pointers or other resource use.
+  ~CRTFileManager();
 
   // Prefetch extracted CRT metadata into metadata cache.
 
@@ -111,10 +126,11 @@ private:
   std::string fCRTVersion;   // Swizzled CRT version (ub_project.version).
   std::string fCRTVersionTop;// Swizzled CRT version for top CRT panels (ub_project.version).
   std::string fCRTMetadataDir; // Directoroy containing extracted CRT metadata.
+  std::string fSchema;       // SAM schema for accessing CRT files.
 
   // This data structure contains information that is known from sam metadata about
   // CRT binary and swizzled files.
-  // The map key is the name of a CRT swizzled file.
+  // The map key is the name of a CRT binary file.
   // The map value contains information about the corresponding CRT binary file.
 
   mutable std::map<std::string, CRTFileInfo> fCRTFiles;

--- a/ubcrt/CRT/CRTFileManager_service.cc
+++ b/ubcrt/CRT/CRTFileManager_service.cc
@@ -1,4 +1,4 @@
-////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////
 // Class:       CRTFileManager
 // Plugin Type: service (art v2_05_01)
 // File:        CRTFileManager_service.cc
@@ -12,8 +12,11 @@
 #include <sstream>
 #include <ctime>
 #include <fstream>
+#include <cstdlib>
+#include <cstdio>
 #include <dirent.h>
 #include <sys/types.h>
+#include <sys/stat.h>
 #include "CRTFileManager.h"
 #include "art/Framework/Services/Registry/ActivityRegistry.h"
 #include "art/Framework/Services/Registry/ServiceMacros.h"
@@ -42,10 +45,71 @@ crt::CRTFileManager::CRTFileManager(fhicl::ParameterSet const & p, art::Activity
   fCRTHitLabel(p.get<std::string>("CRTHitLabel")),
   fCRTVersion(p.get<std::string>("ubversion_CRTHits")),
   fCRTVersionTop(p.get<std::string>("ubversion_CRTHits_top", fCRTVersion)),
-  fCRTMetadataDir(p.get<std::string>("CRTMetadataDir", std::string()))
+  fCRTMetadataDir(p.get<std::string>("CRTMetadataDir", std::string())),
+  fSchema(p.get<std::string>("Schema", std::string()))
 {
   setenv("TZ", "CST6CDT", 1);  // Fermilab time zone.
   tzset();
+
+  // Maybe choose schema based on environment variable CRT_SCHEMA.
+
+  if(fSchema == std::string() && getenv("CRT_SCHEMA") != 0 && *getenv("CRT_SCHEMA") != 0) {
+    fSchema = std::string(getenv("CRT_SCHEMA"));
+  }
+
+  // Maybe use default schema based on following criteria.
+  // 1. Xrootd version.
+  // 2. Availability of valid proxy.
+  // 3. Availability of /pnfs mount.
+  //
+  // Generallly, schema "root" is most preferred, then "file," then "https."
+
+  if(fSchema == std::string()) {
+    std::cout << "SAM schema was not specified as a fcl parameter.\n"
+              << "We will choose a default schema."
+              << std::endl;
+
+    // Check xrootd version.
+
+    std::string xrootd_version("v0");
+    const char* s = getenv("XROOTD_VERSION");
+    if(s != 0 && *s != 0)
+      xrootd_version = std::string(s);
+    std::cout << "Xrootd version = " << xrootd_version << std::endl;
+    if(xrootd_version >= "v5_5")
+      fSchema = "root";
+    else {
+
+      // Xrootd version is too low for tokens.
+      // We can still use schema "root" if we have a valid proxy.
+
+      int rc = system("voms-proxy-info -exists");
+      if(rc == 0) {
+        std::cout << "We have a valid proxy." << std::endl;
+        fSchema = "root";
+      }
+      else {
+
+        // No proxy, check availability of /pnfs, which allows to use schema "file."
+
+        struct stat info;
+        int ok = stat("/pnfs", &info);
+        if(ok == 0 && (info.st_mode & S_IFDIR) != 0) {
+          std::cout << "Filesystem /pnfs is mounted." << std::endl;
+          fSchema = "file";
+        }
+        else {
+
+          // No xrootd, proxy, or pnfs.
+          // Use last resort schema https.
+          
+          std::cout << "No /pnfs mount." << std::endl;
+          fSchema = "https";
+        }
+      }
+    }
+    std::cout << "Using default schema = " << fSchema << std::endl;
+  }
 
   // Message.
 
@@ -54,7 +118,29 @@ crt::CRTFileManager::CRTFileManager(fhicl::ParameterSet const & p, art::Activity
 	    << "  CRT Hit Label = " << fCRTHitLabel  << "\n"
 	    << "  CRT Version = " << fCRTVersion << "\n"
 	    << "  CRT Top Version = " << fCRTVersionTop << "\n"
-	    << "  CRT metadata directory = " << fCRTMetadataDir << std::endl;
+	    << "  CRT metadata directory = " << fCRTMetadataDir << "\n"
+            << "  SAM schema = " << fSchema << std::endl;
+}
+
+
+// Destructor.
+
+crt::CRTFileManager::~CRTFileManager()
+{
+  // Delete local copies of fetched files, if any.
+
+  for(auto const& crt_event : fCRTEvents) {
+    std::string class_name(crt_event.second->getTFile()->ClassName());
+    if(class_name == std::string("TFile") ) {
+      std::string local_filename(crt_event.second->getTFile()->GetName());
+      if(fSchema != std::string("file") && local_filename.substr(0, 5) != std::string("/pnfs")) {
+        std::cout << "Deleting local file " << local_filename << std::endl;
+        remove(local_filename.c_str());
+      }
+    }
+  }
+
+
 }
 
 
@@ -444,23 +530,33 @@ gallery::Event& crt::CRTFileManager::openFile(std::string file_name)
 
   if(fCRTEvents.size() >= fMaxFiles) {
     std::cout << "Closing file " << fCRTEvents.front().first << std::endl;
+
+    // Delete local copy, if any.
+
+    std::string class_name(fCRTEvents.front().second->getTFile()->ClassName());
+    if(class_name == std::string("TFile") ) {
+      std::string local_filename(fCRTEvents.front().second->getTFile()->GetName());
+      if(fSchema != std::string("file") && local_filename.substr(0, 5) != std::string("/pnfs")) {
+        std::cout << "Deleting local file " << local_filename << std::endl;
+        remove(local_filename.c_str());
+      }
+    }
     fCRTEvents.pop_front();
   }
 
-  // Get xrootd url of file.
+  // Get url of file.
 
   art::ServiceHandle<ifdh_ns::IFDH> ifdh;
-  std::string schema = "root";
-  std::vector< std::string > xrootd_urls;
+  std::vector< std::string > urls;
   bool locate_ok = false;
   try {
-    xrootd_urls = ifdh->locateFile(file_name, schema);
+    urls = ifdh->locateFile(file_name, fSchema);
     locate_ok = true;
   }
   catch(...) {
     locate_ok = false;
   }
-  if(!locate_ok || xrootd_urls.size() == 0) {
+  if(!locate_ok || urls.size() == 0) {
     std::cout << "No locations found for root file " << file_name << std::endl;
     throw cet::exception("CRTFileManager") << "Could not locate CRT file: " 
 					   << file_name << "\n";
@@ -469,12 +565,12 @@ gallery::Event& crt::CRTFileManager::openFile(std::string file_name)
   // Filter locations.
   // If there is a "production" location, use that.
   // Otherwise, use the first location.
-  // After filtering, vector xrootd_urls should contain one element with only the preferred url.
+  // After filtering, vector urls should contain one element with only the preferred url.
 
   int np = 0;
-  if(xrootd_urls.size() > 1) {
-    for(size_t i=0; i<xrootd_urls.size(); ++i) {
-      if(xrootd_urls[i].find("/production/") < std::string::npos) {
+  if(urls.size() > 1) {
+    for(size_t i=0; i<urls.size(); ++i) {
+      if(urls[i].find("/production/") < std::string::npos) {
         np = i;
         break;
       }
@@ -482,17 +578,56 @@ gallery::Event& crt::CRTFileManager::openFile(std::string file_name)
   }
 
   if(np > 0)
-    xrootd_urls[0] = xrootd_urls[np];
-  if(xrootd_urls.size() > 1)
-    xrootd_urls.erase(xrootd_urls.begin()+1, xrootd_urls.end());
-  std::cout<<"xrootd URL: " << xrootd_urls[0] << std::endl;
-  
-  // gallery, when fed the list of the xrootd URL, internally calls TFile::Open()
+    urls[0] = urls[np];
+  if(urls.size() > 1)
+    urls.erase(urls.begin()+1, urls.end());
+  std::cout<<"URL: " << urls[0] << std::endl;
+
+  // Maybe copy url to local file.
+  //
+  // Calling fetchInput usually won't do anything if the url is an xrootd url.
+  //
+  // If ifdh decides it needs to copy the url, it uses the following destination
+  // directories, in priority order.
+  //
+  // 1.  $IFDH_DATA_DIR
+  // 2.  $_CONDOR_SCRATCH_DIR
+  // 3.  $TMPDIR
+  // 4.  /var/tmp (last resort).
+  //
+  // Don't ever let ifdh copy to /var/tmp, because that will likely crash the machine.
+  //
+
+  if(getenv("IFDH_DATA_DIR") == 0 &&
+     getenv("_CONDOR_SCRATCH_DIR") == 0 &&
+     getenv("TMPDIR") == 0) {
+    std::cout << "Setting ifdh destination to current directory." << std::endl;
+    putenv(const_cast<char*>("TMPDIR=."));
+  }
+
+  std::vector<std::string> local_filenames;
+
+  // If the url is a file:// url, don't use ifdh fetch, but just strip off the initial "file://".
+
+  if(urls[0].substr(0, 7) == std::string("file://"))
+    local_filenames.push_back(urls[0].substr(7));
+  else
+    local_filenames.push_back(ifdh->fetchInput(urls[0]));
+  std::cout << "Local filename = " << local_filenames[0] << std::endl;
+
+  // gallery, when fed the list of the xrootd URLs, internally calls TFile::Open()
   // to open the file-list
   // In interactive mode, you have to get your proxy authenticated by issuing:
   // voms-proxy-init -noregen -rfc -voms fermilab:/fermilab/uboone/Role=Analysis
   // when you would like to launch a 'lar -c ... ... ...'
   // In batch mode, this step is automatically done
+  //
+  // Update 04/2025:
+  //
+  // Proxies are being disabled.  Ifdh may require a token for authentication.
+  // A valid bearer token should always be available in batch jobs.
+  // Tokens can be gotten interactively by this command:
+  // htgettoken -a htvaultprod.fnal.gov -i <experiment>
     
   // Make several attempts to open file.
 
@@ -512,7 +647,7 @@ gallery::Event& crt::CRTFileManager::openFile(std::string file_name)
 
     try {
       std::cout << "Open file." << std::endl;
-      crt_event = std::unique_ptr<gallery::Event>(new gallery::Event(xrootd_urls));
+      crt_event = std::unique_ptr<gallery::Event>(new gallery::Event(local_filenames));
       open_ok = true;
     }
     catch(...) {
@@ -527,13 +662,13 @@ gallery::Event& crt::CRTFileManager::openFile(std::string file_name)
   }
 
   if(open_ok) {
-    std::cout<< "Opened the CRT root file from xrootd URL" << std::endl;
+    std::cout<< "Opened the CRT root file from URL" << std::endl;
     fCRTEvents.emplace_back(file_name, std::move(crt_event));
     std::cout << "New [collection of] CRTEvent[s]. Its size is  "
 	      << fCRTEvents.back().second->numberOfEventsInFile() << "." << std::endl;
   }
   else {
-    std::cout << "Failed to open CRT root file xrootd URL." << std::endl;
+    std::cout << "Failed to open CRT root file URL." << std::endl;
     //throw cet::exception("CRTFileManager") << "Could not open CRT file: " 
     //				   << file_name << "\n";
 

--- a/ubcrt/CRT/microboone_crt_file_manager.fcl
+++ b/ubcrt/CRT/microboone_crt_file_manager.fcl
@@ -2,7 +2,7 @@ BEGIN_PROLOG
   
 microboone_crt_file_manager: {
   debug:       false
-  maxFiles:    15
+  maxFiles:    6
   CRTHitLabel: "crthit"
   ubversion_CRTHits:  "NoVersion"
   CRTMetadataDir: "/cvmfs/uboone.opensciencegrid.org/crt_metadata"


### PR DESCRIPTION
Give CRTFileManager the ability to use other schemas than root for reading CRT swizzled files.